### PR TITLE
shellcheck fixes and some more

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,49 @@
-pastebin-shell
-==============
+# pastebin-shell
 
-bash pastebin.com client  
-Posts text from stdin to pastebin.com.
+Bash pastebin.com client. Bash Script to post text from `stdin` to [pastebin.com](http://pastebin.com).
+
+## Installation
+
+Download:
+
+	curl -f https://raw.githubusercontent.com/mefuckin/pastebin-shell/master/pbin -o pbin
+	chmox +x pbin
+
+Run:
+
+	./pbin -h
+
+## Usage
+
+	Usage: pbin [options]
+	Post text from stdin to pastebin.com.
+
+	Options:
+		-l				Log into pastebin.com
+		-u				Your pastebin.com username
+		-p				Your pastebin.com password
+		-n name				Paste title
+		-f format			Syntax highlightig format (you can find list 
+						of formats at http://pastebin.com/api#5)
+		-e expire			Paste expire time:
+						  n (or never) - never
+						  10M          - 10 minutes
+						  1H           - 1 hour
+						  1D           - 1 day
+						  1M           - 1 month
+		-r private			Private settings: public (or 0), unlisted (or 1)
+						or private (or 2, need to login)
+		-h				Show this message
+		-o				Print sample config
+		-c /path/to/pastebin.conf	Set path to config file
+
+Examples:
+
+`pbin < /proc/cpuinfo`
+
+
+`echo -e "foo\nbar" | bash pbin -n "foobar.txt" -l 1`
+
+## Requirements
+
+Only `bash` and `curl`.

--- a/pbin
+++ b/pbin
@@ -4,27 +4,30 @@
 # https://github.com/mefuckin/pastebin-shell
 
 # Path to config file
-eval config_file="~/.config/pastebin.conf"
+config_file="$HOME/.config/pastebin.conf"
 
 # Config file overwrites following default settings
 
 # This is my API Developer Key (you can change it here or use config file)
-api_dev_key=97d4dbcc849cf72fe005154e40904f71
+api_dev_key="97d4dbcc849cf72fe005154e40904f71"
 
 # Autologin
-logintopastebin=0
+logintopastebin="0"
 
 # Default paste title, if -n argument is not defined
-api_paste_name=
+api_paste_name=""
 
 # Default paste highlighting, if -f argument is not defined
-api_paste_format=text
+api_paste_format="text"
 
 # Default private settings, if -p argument is not defined (0=public, 1=unlisted, 2=private)
-api_paste_private=0
+api_paste_private="0"
 
 # Default expire date, if -e argument is not defined
-api_paste_expire_date=N
+api_paste_expire_date="1H"
+
+# Pastebin.com API URL
+api_url="http://pastebin.com/api"
 
 usage()
 {
@@ -33,90 +36,104 @@ Usage: $0 [options]
 Post text from stdin to pastebin.com.
 
 Options:
-   -l		Log into pastebin.com
-   -u		Your pastebin.com username
-   -p		Your pastebin.com password
-   -n name	Paste title
-   -f format	Syntax highlightig format (you can find list 
-		   of formats at http://pastebin.com/api#5)
-   -e expire	Paste expire time:
-		  n (or never) - never
-		  10M - 10 minutes
-		   1H - 1 hour
-		   1D - 1 day
-		   1M - 1 month
-   -r private	Private settings: public (or 0), unlisted (or 1)
-		   or private (or 2, need to login)
-   -h		Show this message
-   -o		Print sample config
-   -c /path/to/pastebin.conf	Set path to config file
+	-l				Log into pastebin.com
+	-u				Your pastebin.com username
+	-p				Your pastebin.com password
+	-n name				Paste title
+	-f format			Syntax highlightig format (you can find list 
+					of formats at http://pastebin.com/api#5)
+	-e expire			Paste expire time:
+					  n (or never) - never
+					  10M          - 10 minutes
+					  1H           - 1 hour
+					  1D           - 1 day
+					  1M           - 1 month
+	-r private			Private settings: public (or 0), unlisted (or 1)
+					or private (or 2, need to login)
+	-h				Show this message
+	-o				Print sample config
+	-c /path/to/pastebin.conf	Set path to config file
 EOF
+}
+
+# command_exists() tells if a given command exists.
+function command_exists() {
+	command -v "$1" >/dev/null 2>&1
 }
 
 sample_config()
 {
 cat << EOF
 # Change to your API Developer Key
-#api_dev_key=
+#api_dev_key=""
 
 # Change to your pastebin.com username, if you want to log into your account
-#api_user_name=
+#api_user_name=""
 
 # Change to your pastebin.com password
-#api_user_password=
+#api_user_password=""
 
 # Set to 1 if you want to log into your account automatically
 # (you may login with -l, -u, -p arguments also)
-#logintopastebin=0
+#logintopastebin="0"
 
 # Default paste title, if -n argument is not defined
-#api_paste_name=
+#api_paste_name=""
 
 # Default paste highlighting, if -f argument is not defined
 # (see http://pastebin.com/api#5 for more)
-#api_paste_format=text
+#api_paste_format="text"
 
 # Default private settings, if -p argument is not defined
 # (0=public, 1=unlisted, 2=private)
-#api_paste_private=0
+#api_paste_private="0"
 
 # Default expire date, if -e argument is not defined
-#api_paste_expire_date=N
+#api_paste_expire_date="N"
 EOF
 }
 
 auth_user()
 {
-	if [ -z $api_user_name ] || [ -z $api_user_password ]
+	if [ -z "$api_user_name" ] || [ -z "$api_user_password" ]
 	then
 		echo "Username and/or password is undefined."
-		read -p "Enter your pastebin.com username: " api_user_name
-		read -s -p "Password: " api_user_password
+		echo "Please adjust 'api_user_name' and 'api_user_password' in the configuration file '$config_file'"
+		exit 1
 	fi
 
-	server_reply=`curl --silent -d "api_dev_key=$api_dev_key&api_user_name=$api_user_name&api_user_password=$api_user_password" \
-	http://pastebin.com/api/api_login.php`
+	server_reply="$(curl --silent --data "api_dev_key=$api_dev_key" --data-urlencode "api_user_name=$api_user_name" --data-urlencode "api_user_password=$api_user_password" "$api_url/api_login.php")"
 
 	if [[ $server_reply == Bad* ]]
 	then
-		echo $server_reply
+		echo "Username: $api_user_name"
+		echo "$server_reply"
 		exit 1
 	else
-		api_user_key=$server_reply
+		api_user_key="$server_reply"
 	fi
 }
 
-[ -e $config_file ] && source $config_file
+if ! command_exists curl; then
+	echo "'curl' is needed. Please install 'curl'. More details can be found at https://curl.haxx.se/"
+	exit 1
+fi
+
+# Load configuration file if it exists.
+if [ -f "$config_file" ]; then
+	# shellcheck source=/dev/null
+	source "$config_file"
+fi
 
 while getopts "hu:p:ln:f:c:e:r:o" OPTION ; do
   case $OPTION in
     h) usage; exit ;;
     o) sample_config; exit ;;
-    u) api_user_name=$OPTARG; logintopastebin=1 ;;
-    p) api_user_password=$OPTARG ;;
+    u) api_user_name="$OPTARG"; logintopastebin=1 ;;
+    p) api_user_password="$OPTARG" ;;
     l) logintopastebin=1 ;;
-    n) api_paste_name=$OPTARG ;;
-    f) api_paste_format=$OPTARG ;;
+    n) api_paste_name="$OPTARG" ;;
+    f) api_paste_format="$OPTARG" ;;
     e) case $OPTARG in
         n|never) api_paste_expire_date=N ;;
         10M) api_paste_expire_date=10M ;;
@@ -133,7 +150,7 @@ while getopts "hu:p:ln:f:c:e:r:o" OPTION ; do
 	      private|2)
 		    if [ $logintopastebin -ne 1 ]
 		    then
-		      echo "You need to log in if you want to post private pastes."
+		      echo "You need to log in (option -l or -u) if you want to post private pastes."
 		      exit 1
 		    else
 		      api_paste_private=2
@@ -142,9 +159,10 @@ while getopts "hu:p:ln:f:c:e:r:o" OPTION ; do
 	      *) echo "Invalid private value"; exit 1 ;;
        esac
     ;;
-    c) if [ -e $OPTARG ];
+    c) if [ -f "$OPTARG" ];
 	   then
-	     source $OPTARG
+	     # shellcheck source=/dev/null
+	     source "$OPTARG"
 	   else
 	     echo "$OPTARG is not exists"
 	     exit 1
@@ -154,5 +172,18 @@ while getopts "hu:p:ln:f:c:e:r:o" OPTION ; do
 done
 
 [ $logintopastebin -ne 0 ] && auth_user
-curl -d "api_dev_key=$api_dev_key&api_option=paste&api_paste_code=`cat -`&api_paste_name=$api_paste_name&api_paste_format=$api_paste_format&api_paste_private=$api_paste_private&api_paste_expire_date=$api_paste_expire_date&api_user_key=$api_user_key" http://pastebin.com/api/api_post.php
+api_paste_code=$( cat - )
+curl -0 --show-error \
+	--data "api_dev_key=$api_dev_key" \
+	--data "api_option=paste" \
+	--data "api_paste_code=$api_paste_code" \
+	--data "api_paste_format=$api_paste_format" \
+	--data "api_paste_private=$api_paste_private" \
+	--data "api_paste_expire_date=$api_paste_expire_date" \
+	--data "api_user_key=$api_user_key" \
+	--data-urlencode "api_paste_name=$api_paste_name" \
+	--data-urlencode "api_paste_code=$api_paste_code" \
+		"$api_url/api_post.php"
+
+echo
 exit $?


### PR DESCRIPTION
Tilde does not expand in quotes. Use $HOME.
Double quote to prevent globbing and word splitting.
Remove not working read
Use $(..) instead of legacy `..`.
Better readable curl
README revised